### PR TITLE
Key Spawning changes

### DIFF
--- a/GameClientSide/Scenes/GameIntroLevel.tscn
+++ b/GameClientSide/Scenes/GameIntroLevel.tscn
@@ -492,20 +492,3 @@ shape = SubResource( 19 )
 [node name="humans" type="Node" parent="."]
 
 [node name="creatures" type="Node" parent="."]
-
-[node name="keyPosition" type="Node2D" parent="."]
-
-[node name="keyPos1" type="Position2D" parent="keyPosition"]
-position = Vector2( -1976.64, 1946.71 )
-
-[node name="keyPos2" type="Position2D" parent="keyPosition"]
-position = Vector2( 2681.35, -1912.02 )
-
-[node name="keyPos3" type="Position2D" parent="keyPosition"]
-position = Vector2( -1697.06, -2398.51 )
-
-[node name="keyPos4" type="Position2D" parent="keyPosition"]
-position = Vector2( 3479.63, 794.703 )
-
-[node name="keyPos5" type="Position2D" parent="keyPosition"]
-position = Vector2( 1312.52, 542.387 )

--- a/GameClientSide/Scripts/Client Lobby.gd
+++ b/GameClientSide/Scripts/Client Lobby.gd
@@ -1,7 +1,7 @@
 extends Node2D
 
-const connectIP = "34.94.217.163"
-#const connectIP = "127.0.0.1"
+#const connectIP = "34.94.217.163"
+const connectIP = "127.0.0.1"
 const connectPort = 44444;
 var Player = load("res://Scenes/Player.tscn")
 var Creature = load("res://Scenes/Creature.tscn")
@@ -48,6 +48,7 @@ puppet func spawn_player(spawn_pos, id):
 	player.set_network_master(id)
 	
 	if(id == get_tree().get_network_unique_id()):
+		Gamestate.isHuman = true
 		var camera = Camera2D.new()
 		camera.make_current()
 		camera.set_limit_smoothing_enabled(100)
@@ -64,6 +65,7 @@ puppet func spawn_creature(spawn_pos, id):
 	creature.set_network_master(id)
 	
 	if(id == get_tree().get_network_unique_id()):
+		Gamestate.isHuman = false
 		get_node("/root/GameIntroLevel/black background").hide()
 		var camera = Camera2D.new()
 		camera.make_current()

--- a/GameClientSide/Scripts/GameIntroLevel.gd
+++ b/GameClientSide/Scripts/GameIntroLevel.gd
@@ -3,24 +3,15 @@ extends Node2D
 
 # Declare member variables here. Examples:
 var path
-# var b = "text"
+onready var keyScene = load("res://Scenes/key.tscn")
 
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	var scene = load("res://Scenes/key.tscn")
-	var array = []
-	for i in range(3):
-		var num = (randi() % 5) + 1
-		while num in array:
-			num = (randi() % 5) + 1
-		array.append(num)
+	pass
 
-	print(array)
-	for i in array:
-		var key = scene.instance()
-		var key_pos = get_node("/root/GameIntroLevel/keyPosition/keyPos" + str(i)).position
-		print("key position is ")
-		print(i)
+remote func client_spawn_key(key_pos):
+	if Gamestate.isHuman: #for now, don't let creature see keys
+		var key = keyScene.instance()
 		key.position = key_pos
 		add_child(key)

--- a/GameClientSide/Scripts/gamestate.gd
+++ b/GameClientSide/Scripts/gamestate.gd
@@ -2,4 +2,5 @@ extends Node
 
 #var Player = load("res://Scenes/Player.tscn")
 var numkeys = 0
-var totalKeys = 5
+var totalKeys = 10
+var isHuman = true

--- a/GameServerSide/Scenes/GameIntroLevel.tscn
+++ b/GameServerSide/Scenes/GameIntroLevel.tscn
@@ -497,3 +497,35 @@ position = Vector2( 2311.26, 1536.6 )
 [node name="humans" type="Node" parent="."]
 
 [node name="creatures" type="Node" parent="."]
+
+[node name="keyPosition" type="Node2D" parent="."]
+
+[node name="keyPos1" type="Position2D" parent="keyPosition"]
+position = Vector2( -1976, 1946 )
+
+[node name="keyPos2" type="Position2D" parent="keyPosition"]
+position = Vector2( 1312, 1040 )
+
+[node name="keyPos3" type="Position2D" parent="keyPosition"]
+position = Vector2( 1312, 542 )
+
+[node name="keyPos4" type="Position2D" parent="keyPosition"]
+position = Vector2( 3479, 794 )
+
+[node name="keyPos5" type="Position2D" parent="keyPosition"]
+position = Vector2( 3005.3, -158.571 )
+
+[node name="keyPos6" type="Position2D" parent="keyPosition"]
+position = Vector2( 3088.36, -1117.55 )
+
+[node name="keyPos7" type="Position2D" parent="keyPosition"]
+position = Vector2( 2680.6, -2235.09 )
+
+[node name="keyPos8" type="Position2D" parent="keyPosition"]
+position = Vector2( -1697, -2398 )
+
+[node name="keyPos9" type="Position2D" parent="keyPosition"]
+position = Vector2( -3548.97, -1245.91 )
+
+[node name="keyPos10" type="Position2D" parent="keyPosition"]
+position = Vector2( -2703.26, 1328.98 )

--- a/GameServerSide/Scripts/Creature.gd
+++ b/GameServerSide/Scripts/Creature.gd
@@ -17,7 +17,7 @@ puppet var arrowDirection = 0
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	pass
+	randomize()
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):

--- a/GameServerSide/Scripts/GameIntroLevel.gd
+++ b/GameServerSide/Scripts/GameIntroLevel.gd
@@ -2,8 +2,19 @@ extends Node2D
 
 var Player = load("res://Scenes/Player.tscn")
 var Creature = load("res://Scenes/Creature.tscn")
+var numKeyPositions = 10
 var creatureDeaths = 0
-
+var keyArray = []
+	
+func _ready():
+	randomize()
+	for i in range(3):
+		var num = (randi() % numKeyPositions) + 1
+		while num in keyArray:
+			num = (randi() % numKeyPositions) + 1
+		keyArray.append(num)
+	print("Keys chosen: ", keyArray)
+	
 func spawn_player(spawn_pos, id):
 	var player = Player.instance()
 	player.position = spawn_pos
@@ -19,3 +30,8 @@ func spawn_creature(spawn_pos, id):
 	creature.set_network_master(id)
 	get_node("/root/GameIntroLevel/creatures").add_child(creature)
 	print("    Creature spawned")
+
+func spawn_keys(): #network call to client to spawn keys
+	for i in keyArray:
+		var key_pos = get_node("/root/GameIntroLevel/keyPosition/keyPos" + str(i)).position
+		rpc("client_spawn_key", key_pos)

--- a/GameServerSide/Scripts/LobbyServer.gd
+++ b/GameServerSide/Scripts/LobbyServer.gd
@@ -23,7 +23,7 @@ func _player_connected(id):
 	print("    P", id, " connected to server")
 	ready_players.append(id)
 	#start game once 2 players connect
-	if ready_players.size() == 2:
+	if ready_players.size() == 1:
 		pre_start_game()
 	
 func _player_disconnected(id):
@@ -50,7 +50,7 @@ func pre_start_game():
 		rpc_id(id, "pre_start_game")
 	print("3. Wait for players to set up game")
 	
-remote func post_start_game():
+remote func post_start_game(): #spawn players and objects
 	var caller_id = get_tree().get_rpc_sender_id()
 	print("    P", caller_id, " loaded map")
 	#for id in ready_players:
@@ -61,6 +61,7 @@ remote func post_start_game():
 	if(ready_players.size() == 2):
 		rpc_id( caller_id, "spawn_creature", Vector2(1000, 1000), ready_players[0] )
 		rpc_id( caller_id, "spawn_player", Vector2(500, 300), ready_players[1] )
+	get_node("/root/GameIntroLevel").spawn_keys()
 
 func gameOver(winCode):
 	print("Match Over")


### PR DESCRIPTION
 - key spawning used to be all client side last commit
 - now server handles spawns and network calls the positions to the clients
 - creature can't see keys unless same instance of engine was used to run human and creature player
 - truly random key location and creature respawns now
**_Issues_**
 - server crashes on victory screen, seems to be some kind of heap allocation error (based off what cloud compute engine says)