### PR TITLE
Major Crash Fixes

### DIFF
--- a/GameClientSide/Scripts/Client Lobby.gd
+++ b/GameClientSide/Scripts/Client Lobby.gd
@@ -1,12 +1,12 @@
 extends Node2D
 
-#const connectIP = "34.94.217.163"
-const connectIP = "127.0.0.1"
+const connectIP = "34.94.217.163"
+#const connectIP = "127.0.0.1"
 const connectPort = 44444;
 var Player = load("res://Scenes/Player.tscn")
 var Creature = load("res://Scenes/Creature.tscn")
 var level #used for removing and changing maps
-var victoryScreen = load("res://Scenes/victoryScreen.tscn").instance()
+var victoryScreen = preload("res://Scenes/victoryScreen.tscn")
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	get_tree().connect("connected_to_server", self, "_connected_ok")
@@ -76,10 +76,11 @@ puppet func spawn_creature(spawn_pos, id):
 
 remote func gameOver(winCode):
 	if level:
-		level.free()
-	rpc("localLevelDeleted") #tell server we deleted level
-	get_tree().get_root().add_child(victoryScreen)
+		level.call_deferred('free')
+	rpc_id(1, "localLevelDeleted") #tell server we deleted level
+	print("Victory Screen Displayed")
+	get_tree().get_root().add_child(victoryScreen.instance())
 	if(winCode == 'c'): #switch statement not yet in Godot?
-		get_node("/root/victoryScreen/whoWon").add_text("Creatures Won")
+		get_node("/root/victoryScreen/whoWon").add_text("Creatures Won ")
 	if(winCode == 'h'):
-		get_node("/root/victoryScreen/whoWon").add_text("Humans Won")
+		get_node("/root/victoryScreen/whoWon").add_text("Humans Won ")

--- a/GameServerSide/Scripts/LobbyServer.gd
+++ b/GameServerSide/Scripts/LobbyServer.gd
@@ -5,7 +5,7 @@ var max_clients = 4;
 var playerReady = 0;
 var ready_players = []
 var level
-var victoryScreen = load("res://Scenes/victoryScreen.tscn").instance()
+var victoryScreen = preload("res://Scenes/victoryScreen.tscn")
 var numFinishedPlayers = 0
 
 func _ready():
@@ -23,7 +23,7 @@ func _player_connected(id):
 	print("    P", id, " connected to server")
 	ready_players.append(id)
 	#start game once 2 players connect
-	if ready_players.size() == 1:
+	if ready_players.size() == 2:
 		pre_start_game()
 	
 func _player_disconnected(id):
@@ -71,5 +71,6 @@ remote func localLevelDeleted(): #server removes level once all clients remove l
 	numFinishedPlayers += 1
 	if(numFinishedPlayers == ready_players.size()):
 		numFinishedPlayers = 0
-		level.free()
-		get_tree().get_root().add_child(victoryScreen)
+		print("Player deleted level")
+		level.queue_free()
+		get_tree().get_root().add_child(victoryScreen.instance())


### PR DESCRIPTION
 - game no longer crashes once victory screen displayed
 - use call_deferred('free') over free() or queue_free() for Client side deletion of level
    - free() instantly removes level resulting in all physics processes failing, queue_free() removes level once Godot thinks its safe, still results in lots of physics processes failing on both server and client sides
       - call_deferred removes level at start of next physics frame, compeltely reduces physics processes failing on server side since clients remove level first; there are minor errors on client side due to not being able to sync player position to server but these are minor and I will look for a fix