### PR TITLE
Lower Hit Flash

### DIFF
--- a/GameClientSide/Scripts/Creature.gd
+++ b/GameClientSide/Scripts/Creature.gd
@@ -35,7 +35,7 @@ func _ready():
 func _process(delta):
 	if(isGreen):
 		hitCounter += 1
-		if(hitCounter > 10):
+		if(hitCounter > 4):
 			hitCounter = 0
 			modulate = Color(0, 0, 0, 1)
 			isGreen = false

--- a/GameClientSide/Scripts/Player.gd
+++ b/GameClientSide/Scripts/Player.gd
@@ -25,7 +25,7 @@ func _ready():
 func _process(delta):
 	if(isGreen):
 		hitCounter += 1
-		if(hitCounter > 5):
+		if(hitCounter > 4):
 			hitCounter = 0
 			modulate = Color(0, 0, 0, 1)
 			isGreen = false


### PR DESCRIPTION
 - on hit, either character will flash for 5/60 of a second instead of 6/60 or 11/60
 - Color modulate property used on characters as a hitmarker has been easier to see, so lowering the time it's active makes it easier to play with